### PR TITLE
Reduce overhead in build.

### DIFF
--- a/.github/workflows/msbuild.yml
+++ b/.github/workflows/msbuild.yml
@@ -15,49 +15,9 @@ env:
   VCPKG_BINARY_SOURCES: 'clear;nuget,GitHub,readwrite'
 
 jobs:
-  vcpkg:
-    strategy:
-      matrix:
-        platform: [x86, x64]
-        include:
-          - platform: x86
-            triplet: x86-windows
-          - platform: x64
-            triplet: x64-windows
-    runs-on: windows-latest
-    env:
-      VCPKG_DEFAULT_TRIPLET: ${{ matrix.triplet }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Restore from cache and install vcpkg
-      uses: lukka/run-vcpkg@v10
-      with:
-        vcpkgGitCommitId: ${{ env.VCPKG_COMMIT }}
-        appendedCacheKey: ${{ matrix.triplet }}
-        vcpkgGitURL: https://github.com/rioki/vcpkg
-    - name: 'Setup NuGet/Vcpkg Credentials'
-      shell: 'bash'
-      run: >
-        `./vcpkg/vcpkg fetch nuget | tail -n 1` \
-          sources add \
-          -source "https://nuget.pkg.github.com/rioki/index.json" \
-          -storepasswordincleartext \
-          -name "GitHub" \
-          -username "rioki" \
-          -password "${{ secrets.GITHUB_TOKEN }}"
-        `./vcpkg/vcpkg fetch nuget | tail -n 1` \
-          setapikey "${{ secrets.GITHUB_TOKEN }}" \
-          -source "https://nuget.pkg.github.com/rioki/index.json"
-    - name: Integrate vcpkg in MSBuild
-      shell: 'bash'
-      run: >
-        ./vcpkg/vcpkg install
   build:
-    needs: vcpkg
     strategy:
       matrix:
-        configuration: [Release, Debug]
         platform: [x86, x64]
         include:
           - platform: x86
@@ -95,9 +55,15 @@ jobs:
       shell: 'bash'
       run: >
         ./vcpkg/vcpkg integrate install
-    - name: Build
+    - name: Build (Debug)
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: msbuild /m /p:Configuration=${{matrix.configuration}} /property:Platform=${{matrix.platform}} ice.sln
-    - name: Test
+      run: msbuild /m /p:Configuration=Debug /property:Platform=${{matrix.platform}} ice.sln
+    - name: Test (Debug)
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: bin/${{matrix.platform}}/${{matrix.configuration}}/ice-test.exe --gtest_filter=-*.GRAPHICAL_*:*.NOCI_*
+      run: bin/${{matrix.platform}}/Debug/ice-test.exe --gtest_filter=-*.GRAPHICAL_*:*.NOCI_*
+    - name: Build (Release)
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m /p:Configuration=Release /property:Platform=${{matrix.platform}} ice.sln
+    - name: Test (Release)
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: bin/${{matrix.platform}}/Release/ice-test.exe --gtest_filter=-*.GRAPHICAL_*:*.NOCI_*


### PR DESCRIPTION
The CI now builds debug and release in series, which means that
- vcpkg does will not do work twice for each config
- overhead such as checkouts are will be done less
- each individual build may take longer
- less CI time is wasted